### PR TITLE
Add platform target to project files to fix warnings in some tools

### DIFF
--- a/Rubjerg.Graphviz.NugetTest/Rubjerg.Graphviz.NugetTest.csproj
+++ b/Rubjerg.Graphviz.NugetTest/Rubjerg.Graphviz.NugetTest.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net48</TargetFramework>
     <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
     <Authors>Chiel ten Brinke</Authors>
     <Company>Rubjerg</Company>
     <RestorePackagesPath>..\packages</RestorePackagesPath>

--- a/Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
+++ b/Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net48</TargetFramework>
     <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
     <Authors>Chiel ten Brinke</Authors>
     <Company>Rubjerg</Company>
     <RestorePackagesPath>..\packages</RestorePackagesPath>

--- a/Rubjerg.Graphviz.TransitiveNugetTest/Rubjerg.Graphviz.TransitiveNugetTest.csproj
+++ b/Rubjerg.Graphviz.TransitiveNugetTest/Rubjerg.Graphviz.TransitiveNugetTest.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net48</TargetFramework>
     <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
     <Authors>Chiel ten Brinke</Authors>
     <Company>Rubjerg</Company>
     <RestorePackagesPath>..\packages</RestorePackagesPath>

--- a/Rubjerg.Graphviz.TransitiveTest/Rubjerg.Graphviz.TransitiveTest.csproj
+++ b/Rubjerg.Graphviz.TransitiveTest/Rubjerg.Graphviz.TransitiveTest.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net48</TargetFramework>
     <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
     <Authors>Chiel ten Brinke</Authors>
     <Company>Rubjerg</Company>
     <RestorePackagesPath>..\packages</RestorePackagesPath>

--- a/Rubjerg.Graphviz/Rubjerg.Graphviz.csproj
+++ b/Rubjerg.Graphviz/Rubjerg.Graphviz.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net48</TargetFramework>
     <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1701;1702;NU5100</NoWarn>
     <Version>1.0.8</Version>


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/issues/1553