### PR TITLE
Test nonportable build

### DIFF
--- a/.github/workflows/win-build-nonportable.yml
+++ b/.github/workflows/win-build-nonportable.yml
@@ -1,0 +1,36 @@
+name: win-build-nonportable
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+
+on:
+  push:         { branches: [ master ] }
+  pull_request: { branches: [ master ] }
+  release:      { types: [published] }      # runs on “Publish release” button
+  workflow_dispatch:                        # lets you run it by hand
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout Code
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Setup NuGet.exe for use with actions
+      uses: NuGet/setup-nuget@v1.0.5
+        
+    - name: Setup Just
+      uses: extractions/setup-just@v3
+
+    - name: Build and test
+      run: just test-win-x64

--- a/Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
+++ b/Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
@@ -9,6 +9,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
+    <!-- Need to list these in order to do a nonportable build -->
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Rubjerg.Graphviz.TransitiveTest/Rubjerg.Graphviz.TransitiveTest.csproj
+++ b/Rubjerg.Graphviz.TransitiveTest/Rubjerg.Graphviz.TransitiveTest.csproj
@@ -9,6 +9,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
+    <!-- Need to list these in order to do a nonportable build -->
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/justfile
+++ b/justfile
@@ -19,6 +19,9 @@ build SOLUTION:
         dotnet build {{SOLUTION}} --configuration Release --no-restore; \
     fi
 
+build-rid SOLUTION RID:
+    dotnet build {{SOLUTION}} --configuration Release --no-restore -r {{RID}};
+
 # Build nuget package
 build-package: restore
     just build Rubjerg.Graphviz.sln
@@ -53,6 +56,13 @@ test-nugetorg:
     just build NugetOrgTests/Rubjerg.Graphviz.NugetOrgTests.sln
     just test NugetOrgTests/Rubjerg.Graphviz.NugetOrgTest/Rubjerg.Graphviz.NugetOrgTest.csproj
     just test NugetOrgTests/Rubjerg.Graphviz.NugetOrgTransitiveTest/Rubjerg.Graphviz.NugetOrgTransitiveTest.csproj
+
+# Build and test nonportable win-x64 deployment
+test-win-x64: restore-tests
+    dotnet build Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj --configuration Release --no-restore -r win-x64;
+    dotnet build Rubjerg.Graphviz.TransitiveTest/Rubjerg.Graphviz.TransitiveTest.csproj --configuration Release --no-restore -r win-x64;
+    just test Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
+    just test Rubjerg.Graphviz.TransitiveTest/Rubjerg.Graphviz.TransitiveTest.csproj
 
 locate-nupkg GITHUB_OUTPUT:
     echo "package=$(find . -name "Rubjerg.Graphviz.*.nupkg" | head -1)" >> "{{GITHUB_OUTPUT}}"


### PR DESCRIPTION
Tests only on windows, since on linux this wouldn't work because dotnet flattens the native directory structure.