### PR TITLE
Remove reference to version number in test project

### DIFF
--- a/Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
+++ b/Rubjerg.Graphviz.Test/Rubjerg.Graphviz.Test.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Rubjerg.Graphviz">
-      <Version>2.0.*-*</Version>
+      <Version>*-*</Version>
     </PackageReference>
     <PackageReference Include="NUnit.ConsoleRunner">
       <Version>3.18.3</Version>


### PR DESCRIPTION
Fixes https://github.com/Rubjerg/Graphviz.NetWrapper/issues/104
Looks like the version 2.0.*-* matches any version after 2.0, but I'd rather remove the 2.0 part because it's confusing.