### PR TITLE
Add support for s390x (IBM Z) architecture

### DIFF
--- a/Rubjerg.Graphviz/GraphvizCommand.cs
+++ b/Rubjerg.Graphviz/GraphvizCommand.cs
@@ -27,7 +27,9 @@ public class GraphvizCommand
                 Architecture.Arm64 => "arm64",
                 Architecture.X86 => "x86",
                 Architecture.Arm => "arm",
-                Architecture.S390x => "s390x",
+#if NET6_0_OR_GREATER
+                Architecture.S390x => "s390x",  // s390x support added in .NET 6
+endif
                 _ => "unknown"
             };
 
@@ -130,5 +132,6 @@ public class GraphvizCommand
         }
     }
 }
+
 
 

--- a/Rubjerg.Graphviz/GraphvizCommand.cs
+++ b/Rubjerg.Graphviz/GraphvizCommand.cs
@@ -27,9 +27,9 @@ public class GraphvizCommand
                 Architecture.Arm64 => "arm64",
                 Architecture.X86 => "x86",
                 Architecture.Arm => "arm",
-#if NET6_0_OR_GREATER
-                Architecture.S390x => "s390x",  // s390x support added in .NET 6
-#endif
+                // Cast allows compilation in .NET Standard 2.0/2.1.
+                // (Architecture)5 is S390x, added in .NET 6.
+                (Architecture)5 => "s390x",
                 _ => "unknown"
             };
 

--- a/Rubjerg.Graphviz/GraphvizCommand.cs
+++ b/Rubjerg.Graphviz/GraphvizCommand.cs
@@ -29,7 +29,7 @@ public class GraphvizCommand
                 Architecture.Arm => "arm",
 #if NET6_0_OR_GREATER
                 Architecture.S390x => "s390x",  // s390x support added in .NET 6
-endif
+#endif
                 _ => "unknown"
             };
 
@@ -132,6 +132,4 @@ endif
         }
     }
 }
-
-
 

--- a/Rubjerg.Graphviz/GraphvizCommand.cs
+++ b/Rubjerg.Graphviz/GraphvizCommand.cs
@@ -27,6 +27,7 @@ public class GraphvizCommand
                 Architecture.Arm64 => "arm64",
                 Architecture.X86 => "x86",
                 Architecture.Arm => "arm",
+                Architecture.S390x => "s390x",
                 _ => "unknown"
             };
 
@@ -129,4 +130,5 @@ public class GraphvizCommand
         }
     }
 }
+
 


### PR DESCRIPTION
# Add support for s390x (IBM Z) architecture

## Summary
This PR adds support for s390x architecture (IBM Z/zLinux) to the Graphviz.NetWrapper library.

## Problem
Currently, when running on s390x architecture, the library doesn't recognize it and falls back to "unknown", resulting in incorrect runtime identifier paths (`linux-unknown` instead of `linux-s390x`).

## Solution
Added `Architecture.S390x` case to the architecture detection switch statement in `GraphvizCommand.cs`.

## Changes
- Modified `Rubjerg.Graphviz/GraphvizCommand.cs` to include s390x architecture detection

## Compatibility
- No breaking changes
- Backward compatible with existing architectures
- Uses standard .NET `Architecture.S390x` enum value (available since .NET 6)

## Additional Context
- This enables the library to work properly on IBM Z systems without workarounds

Fixes #118